### PR TITLE
ngx_echo/ngx_print: add support for non-string and non-byte objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ngx_python
 
 Requirement
 -----------
-- python 2.7.*
+- python 3.*
 - nginx-1.6.3+ 
 
 Installation
@@ -19,7 +19,7 @@ $ wget 'http://nginx.org/download/nginx-1.6.3.tar.gz'
 $ tar -zxvf nginx-1.6.3.tar.gz
 $ cd nginx-1.6.3
 
-$ export PYTHON_INC=/path/to/python/include/python2.7
+$ export PYTHON_INC=/path/to/python/include/python3.7m
 $ export PYTHON_BIN=/path/to/python/bin
 
 $ ./configure --user=www --group=www \

--- a/src/python/python_ngx.c
+++ b/src/python/python_ngx.c
@@ -28,16 +28,9 @@ ngx_echo(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if (PyBytes_Check(object)) {
-        ns.len = PyBytes_GET_SIZE(object);
-        ns.data = (u_char *)PyBytes_AS_STRING(object);
-    }else if (PyUnicode_Check(object)){
-        ns.len = PyUnicode_GET_SIZE(object);
-        ns.data = (u_char *)PyUnicode_AsUTF8(object);
-    }else {
-        ns.data = (u_char *)" ";
-        ns.len = 1;
-    }
+    PyObject *s;
+    s = PyObject_Str(object);
+    ns.data = (u_char *)PyUnicode_AsUTF8AndSize(s, (Py_ssize_t *)&ns.len);
 
     if (ctx->rputs_chain == NULL){
         chain = ngx_pcalloc(r->pool, sizeof(ngx_http_python_rputs_chain_list_t));
@@ -89,16 +82,9 @@ ngx_print(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if (PyBytes_Check(object)) {
-        ns.len = PyBytes_GET_SIZE(object);
-        ns.data = (u_char *)PyBytes_AS_STRING(object);
-    }else if (PyUnicode_Check(object)){
-        ns.len = PyUnicode_GET_SIZE(object);
-        ns.data = (u_char *)PyUnicode_AsUTF8(object);
-    }else {
-        ns.data = (u_char *)" ";
-        ns.len = 1;
-    }
+    PyObject *s;
+    s = PyObject_Str(object);
+    ns.data = (u_char *)PyUnicode_AsUTF8AndSize(s, (Py_ssize_t *)&ns.len);
 
     if (ctx->rputs_chain == NULL){
         chain = ngx_pcalloc(r->pool, sizeof(ngx_http_python_rputs_chain_list_t));


### PR DESCRIPTION
This change allows ngx_echo() and ngx_print() to handle non-string and non-byte Python objects, as in the following example:
```
a = [1,2,3,4,5]
ngx.echo(a)
```
In addition, Python references in the README have been changed from Python 2.7 to Python 3.*.